### PR TITLE
Add ability to force image creation

### DIFF
--- a/dir2fat32.sh
+++ b/dir2fat32.sh
@@ -50,6 +50,7 @@ usage() {
   echo
   echo "Options:"
   echo "  -S SECSIZE  logical sector size (default: 512)"
+  echo "  -f          overwrite existing image file (if any)"
   echo "  -h          show this message and exit"
   echo
   echo "Valid values for SECSIZE are: 512, 1024, 2048, 4096, 8912, 16384, and "
@@ -126,11 +127,14 @@ insertpart() {
 }
 
 # Parse options
-while getopts "hS:" opt; do
+while getopts "hfS:" opt; do
   case "$opt" in
     h)
       usage
       exit 0
+      ;;
+    f)
+      FORCE=1
       ;;
     S)
       LOGICAL_SECTOR_SIZE=$OPTARG
@@ -145,6 +149,8 @@ done
 OUTPUT=${@:$OPTIND:1}
 SIZE=${@:$OPTIND+1:1}
 SOURCE=${@:$OPTIND+2:1}
+
+[ $FORCE ] && (rm -f $OUTPUT 2>/dev/null || true)
 
 if [ -z "$OUTPUT" ] || [ -z "$SIZE" ] || [ -z "$SOURCE" ]; then
   echo "ERROR: Missing required arguments, please see usage instructions"

--- a/dir2fat32.sh
+++ b/dir2fat32.sh
@@ -41,7 +41,7 @@ WIN95_FAT32=b
 WRITE=w
 
 usage() {
-  echo "Usage: $(basename $0) [-h -S SECSIZE] OUTPUT SIZE SOURCE"
+  echo "Usage: $(basename $0) [-h -f -S SECSIZE] OUTPUT SIZE SOURCE"
   echo
   echo "Arguments:"
   echo "  OUTPUT      name of the image file"
@@ -150,13 +150,14 @@ OUTPUT=${@:$OPTIND:1}
 SIZE=${@:$OPTIND+1:1}
 SOURCE=${@:$OPTIND+2:1}
 
-[ $FORCE ] && (rm -f $OUTPUT 2>/dev/null || true)
 
 if [ -z "$OUTPUT" ] || [ -z "$SIZE" ] || [ -z "$SOURCE" ]; then
   echo "ERROR: Missing required arguments, please see usage instructions"
   usage
   exit 0
 fi
+
+[ $FORCE ] && (rm -f $OUTPUT 2>/dev/null || true)
 
 if [ -e "$OUTPUT" ]; then
   echo "ERROR: $OUTPUT already exists. Aborting."


### PR DESCRIPTION
Normally, the image is not created if the output file exists. This patch adds -f option which allows the user to force image creation.
