### PR TITLE
add "conv=notrunc" when calling dd in insertpart

### DIFF
--- a/dir2fat32.sh
+++ b/dir2fat32.sh
@@ -133,7 +133,7 @@ copyfiles() {
 }
 
 insertpart() {
-  dd if="$PARTITION" of="$OUTPUT" bs=$SECTOR_SIZE seek=$OFFSET_8MB >/dev/null \
+  dd conv=notrunc if="$PARTITION" of="$OUTPUT" bs=$SECTOR_SIZE seek=$OFFSET_8MB >/dev/null \
     2>&1
 }
 


### PR DESCRIPTION
If this option is not present, dd opens the output file with O_TRUNC, zeroing out the container before seeking to the partition start:

> O_TRUNC
>> If the file already exists and is a regular file and the open mode allows writing (i.e., is O_RDWR or O_WRONLY) it will be truncated to length 0. If the file is a FIFO or terminal device file, the O_TRUNC flag is ignored. Otherwise the effect of O_TRUNC is unspecified.